### PR TITLE
Fix minor spacing issue in the snap format documentation

### DIFF
--- a/docs/reference/development/yaml-schemas/the-snap-format.md
+++ b/docs/reference/development/yaml-schemas/the-snap-format.md
@@ -163,11 +163,11 @@ apps:
       refresh-mode:  endure | restart
 
       # Maps a daemon’s sockets to services and activates them.
-     sockets:
+      sockets:
           - <socket name>
 
       # The mode of a socket in octal, such as `0644`.
-     socket-mode: <mode>
+      socket-mode: <mode>
      
       # Controls how the daemon should be stopped.  The given signal is sent to the main PID 
       # (when used without -all) or to all PIDs in the process group when the -all suffix is used.


### PR DESCRIPTION
This just fixes two entries that were misaligned. 

Not addressed in this PR, I also noticed that 2-space indent is used in some parts of the page while 4-space is used in others. Not sure if it is intentional or if the inconsistency matters.