### PR TITLE
Document client libraries used to interact with snapd's REST API

### DIFF
--- a/docs/how-to-guides/snap-development/use-the-rest-api.md
+++ b/docs/how-to-guides/snap-development/use-the-rest-api.md
@@ -79,9 +79,9 @@ Example:
     "type": "sync",
     "status-code": 200,
     "status": "OK",
-    "maintenance": { 
-        "kind": "system-restart", 
-        "message": "system is restarting" 
+    "maintenance": {
+        "kind": "system-restart",
+        "message": "system is restarting"
     }
 }
 ```
@@ -170,3 +170,14 @@ In addition to the standard response fields the following can be present:
 * `kind`: Unique code for the error, to enable a snapd client to display appropriate behaviour (_optional_)
 * `value`: extra information on the error, typically a string for the snap name or an object with fields dependent on the kind (_optional_)
 
+## Client libraries
+
+### Python
+
+The [snap-http](https://github.com/canonical/snap-http) package provides a Python interface to the snapd REST API:
+
+```
+pip install snap-http
+```
+
+See the [snap-http repository](https://github.com/canonical/snap-http) for documentation and usage examples.

--- a/docs/reference/development/index.md
+++ b/docs/reference/development/index.md
@@ -19,6 +19,10 @@ YAML schemas define exactly what a device, kernel and snap is capable of.
  - {ref}`Gadget snap <reference-development-yaml-schemas-the-gadget-snap>`: System and device properties. 
  - {ref}`Kernel snap <reference-development-yaml-schemas-the-kernel-snap>`: The Linux kernel snap, its metadata and setup files.
 
+## Client libraries
+
+* [snap-http](https://github.com/canonical/snap-http): A Python library for interacting with the snapd REST API (`pip install snap-http`).
+
 ```{toctree}
 :hidden:
 :titlesonly:


### PR DESCRIPTION
@Perfect5th and I have been working on a Python library for the snapd REST API for the past two years. The library does not have full feature parity with the API but [it covers a lot of the API surface](https://github.com/canonical/snap-http/blob/main/snap_http/api/__init__.py) and it's currently used in Landscape Client.

This PR adds it to the new _client libraries_ section of the development reference and the REST API how-to guide.