### PR TITLE
Adds Mermaid to the docs configuration

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -409,6 +409,7 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx_sitemap",
     "sphinxext.rediraffe",
+    "sphinxcontrib.mermaid",
 ]
 
 # Excludes files or directories from processing

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -33,3 +33,4 @@ vale
 
 # For snap-docs
 sphinxext-rediraffe
+sphinxcontrib-mermaid


### PR DESCRIPTION
(cc @ernestl)

With this configuration change, we can now embed [Mermaid diagrams](https://mermaid.js.org/) within our documentation.

In MyST, diagrams are placed within ` ```{mermaid}`  ` ``` ` blocks, such as for the following timeline:

```{mermaid}
%%{init: {"theme":"forest"}}%%
timeline
    title Ubuntu recent releases

    2020 : 20.04 LTS (Focal Fossa) : 20.10 (Groovy Gorilla)
    2021 : 21.04 (Hirsute Hippo) : 21.10 (Impish Indri)   
    2022 : 22.04 LTS (Jammy Jellyfish) : 22.10 (Kinetic Kudu)
    2023 : 23.04 (Lunar Lobster) : 23.10 (Mantic Minotaur)
    2024 : 24.04 LTS (Noble Numbat) : 24.10 (Oracular Oriole)
    2025 : 25.04 (Plucky Puffin)
```

See https://canonical-starter-pack.readthedocs-hosted.com/stable/how-to/diagrams-as-code-mermaid for further details.
