### PR TITLE
Fix outdated confdb how-to examples

### DIFF
--- a/docs/how-to-guides/manage-snaps/configure-snaps-with-confdb.md
+++ b/docs/how-to-guides/manage-snaps/configure-snaps-with-confdb.md
@@ -56,7 +56,7 @@ For example:
       "schema": {
         "wifi": {
           "schema": {
-            "psk": "$password",
+            "psk": "${password}",
             "ssid": "string",
             "state": {
               "type": "string",
@@ -120,10 +120,8 @@ views:
       content:
         -
         storage: ssid
-        access: read
         -
         storage: state
-        access: read
 
 body-length: 552
 sign-key-sha3-384: 74KHeq1foV…
@@ -168,10 +166,8 @@ views:
         content:
           -
             storage: ssid
-            access: read
           -
             storage: state
-            access: read
 
 body: |-
   {
@@ -186,7 +182,7 @@ body: |-
         "wifi": {
           "values": {
             "schema": {
-              "psk": "$password",
+              "psk": "${password}",
               "ssid": "string",
               "state": {
                 "choices": ["up", "down"],


### PR DESCRIPTION
Fix confdb how-to examples that have become outdated. The reference to aliases is now ${..} and "access" fields in the confdb-schema are inherited by content sub-rules and cannot be overridden.