### PR TITLE
reference: add Model Service references

### DIFF
--- a/docs/reference/administration/network-requirements.md
+++ b/docs/reference/administration/network-requirements.md
@@ -33,8 +33,9 @@ As of 2021-10-25, the *.snapcraftcontent.com domains are the following:
 Snapcraft also requires:
 * upload.apps.ubuntu.com:443
 
-Devices being provisioned for brand stores will need the following:
-* serial-vault-partners.canonical.com:443
+Devices being provisioned for Dedicated Snap Stores will need the following:
+* api.snapcraft.io/v1:443 # the Model Service
+* serial-vault-partners.canonical.com:443 # The legacy Serial Vault
 
 ### Deprecated cdn.snapcraft.io domains
 

--- a/docs/reference/development/yaml-schemas/the-gadget-snap.md
+++ b/docs/reference/development/yaml-schemas/the-gadget-snap.md
@@ -350,7 +350,7 @@ The device initialisation process is, for example, responsible for setting the s
 
 The `prepare-device` hook can for example redirect this exchange and dynamically set options relevant to it.
 
-One must ensure that `registration.proposed-serial`  is set to a _unique value_  across all devices of the brand and model and that it does not contain a `/`. It is going to be used as the "serial number" (a string, not necessarily a number) part of the identification in case the device service supports setting it or **requires** it, as is the case with the *serial-vault*. **Important:** Ensure the `-s` option is used with `set` when setting the serial.
+One must ensure that `registration.proposed-serial`  is set to a _unique value_  across all devices of the brand and model and that it does not contain a `/`. It is going to be used as the "serial number" (a string, not necessarily a number) part of the identification in case the device service supports setting it or **requires** it, as is the case with the *Model Service* or *Serial Vault*. **Important:** Ensure the `-s` option is used with `set` when setting the serial.
 
 ### prepare-device options
 


### PR DESCRIPTION
CF https://github.com/canonical/ubuntu-core-docs/pull/337

Merely extending some references to reflect the current state of Model Service + Serial Vault. Probably fine to merge right away.