### PR TITLE
snap-docs: document asynchronous changes to snapctl

### DIFF
--- a/docs/how-to-guides/manage-snaps/manage-updates.md
+++ b/docs/how-to-guides/manage-snaps/manage-updates.md
@@ -258,6 +258,8 @@ Done    today at 15:16 BST  today at 15:16 BST  Clean up "gnome-system-monitor" 
 Done    today at 15:16 BST  today at 15:16 BST  Run configure hook of "gnome-system-monitor" snap if present
 ```
 
+Optionally, the `--format` flag may be passed with the `json` argument to return the data as JSON rather than a tabular representation.
+
 ## Revert to an earlier revision
 
 A snap may be reverted to an earlier revision with the `snap revert` command. By default, it will attempt to revert to the previous revision:

--- a/docs/how-to-guides/snap-development/use-snapctl.md
+++ b/docs/how-to-guides/snap-development/use-snapctl.md
@@ -102,15 +102,11 @@ snapctl remove +<comp_name>
 
 If these commands are run from a {ref}`hook <reference-development-supported-snap-hooks>`, the components will be installed/removed after the hook itself has run if it ended successfully.
 
-## snapctl commands
-
-From within a snap, the [snapctl](https://snapcraft.io/docs/using-snapctl) command can be used to install and remove components from an application, including snap hooks and component hooks. The commands for this are:
-
-$ snapctl install +<comp_name>
-
-$ snapctl remove +<comp_name>
-
-If these commands are run from a hook, the components will be installed/removed after the hook itself has run if it ended successfully.
+### Asynchronous Operation
+These commands are run synchronously by default, however, if snapctl supports the _async_ feature, then the `--no-wait` flag can be used to
+immediately return a change ID, which can then be polled with snapctl is-ready <change-id>. To view all change-ids associated with a snapctl
+context, the command `snapctl tasks` may be used. Optionally, the `--json` flag may be passed to return the data as JSON rather than a tabular
+representation.
 
 ## Health state
 

--- a/docs/how-to-guides/snap-development/use-snapctl.md
+++ b/docs/how-to-guides/snap-development/use-snapctl.md
@@ -107,15 +107,15 @@ snapctl remove +<comp_name>
 If these commands are run from a {ref}`hook <reference-development-supported-snap-hooks>`, the components will be installed/removed after the hook itself has run if it ended successfully.
 
 ### Asynchronous Operation
-By default, the `install` and `remove` subcommands run synchronously and will block until the change they create is completed.
+By default, the `install` and `remove` sub-commands run synchronously and will block until the change they create is completed.
 
-The --no-wait flag can be used with install and remove to indicate that snapctl should not block on the created change. Instead, snapctl will immediately return the change ID. This has similar semantics to --no-wait when used with snap install/refresh. This change ID should be used with the is-ready and tasks subcommands.
+The --no-wait flag can be used with install and remove to indicate that snapctl should not block on the created change. Instead, snapctl will immediately return the change ID. This has similar semantics to --no-wait when used with snap install/refresh. This change ID should be used with the is-ready and tasks sub-commands.
 
-The is-ready subcommand enables polling the given change until it has reached a terminal state. See snapctl is-ready --help for a detailed breakdown of the exit codes used.
+The is-ready sub-command enables polling the given change until it has reached a terminal state. See snapctl is-ready --help for a detailed breakdown of the exit codes used.
 
-The tasks subcommand prints detailed information about the given change. This includes information such as the exact state of the change and the progress of individual tasks within the change. Provide the --format=json argument to receive JSON output, rather than the default tabular representation.
+The tasks sub-command prints detailed information about the given change. This includes information such as the exact state of the change and the progress of individual tasks within the change. Provide the --format=json argument to receive JSON output, rather than the default tabular representation.
 
-Note that both snapctl is-ready and snapctl tasks can only be used with changes that were created by the snap in which they are being invoked. Arbitrary changes on the system cannot be introspected via these subcommands.
+Note that both snapctl is-ready and snapctl tasks can only be used with changes that were created by the snap in which they are being invoked. Arbitrary changes on the system cannot be introspected via these sub-commands.
 
 ## Health state
 

--- a/docs/how-to-guides/snap-development/use-snapctl.md
+++ b/docs/how-to-guides/snap-development/use-snapctl.md
@@ -107,11 +107,15 @@ snapctl remove +<comp_name>
 If these commands are run from a {ref}`hook <reference-development-supported-snap-hooks>`, the components will be installed/removed after the hook itself has run if it ended successfully.
 
 ### Asynchronous Operation
-By default installation and removal commands are run synchronously and will block until the change is completed.
+By default, the `install` and `remove` subcommands run synchronously and will block until the change they create is completed.
 
-To enable deeper insight of the change, the `--no-wait` flag can be passed. In this case, the change-id is returned immediately and the user can poll `snapctl is-ready` to determine when the change has finished.
+The --no-wait flag can be used with install and remove to indicate that snapctl should not block on the created change. Instead, snapctl will immediately return the change ID. This has similar semantics to --no-wait when used with snap install/refresh. This change ID should be used with the is-ready and tasks subcommands.
 
-To view all tasks associated with a change-id in the same snapctl context, the command `snapctl tasks` may be used. Optionally, the `--format` flag may be passed with the `json` argument to return the data as JSON rather than a tabular representation.
+The is-ready subcommand enables polling the given change until it has reached a terminal state. See snapctl is-ready --help for a detailed breakdown of the exit codes used.
+
+The tasks subcommand prints detailed information about the given change. This includes information such as the exact state of the change and the progress of individual tasks within the change. Provide the --format=json argument to receive JSON output, rather than the default tabular representation.
+
+Note that both snapctl is-ready and snapctl tasks can only be used with changes that were created by the snap in which they are being invoked. Arbitrary changes on the system cannot be introspected via these subcommands.
 
 ## Health state
 

--- a/docs/how-to-guides/snap-development/use-snapctl.md
+++ b/docs/how-to-guides/snap-development/use-snapctl.md
@@ -109,7 +109,7 @@ If these commands are run from a {ref}`hook <reference-development-supported-sna
 ### Asynchronous Operation
 By default, the `install` and `remove` sub-commands run synchronously and will block until the change they create is completed.
 
-The `--no-wait` flag can be used with `install` and `remove` to indicate that snapctl should not block on the created change. Instead, snapctl will immediately return the change ID. This has similar semantics to `--no-wait` when used with `snap install/refresh`. This change ID should be used with the `is-ready` and `tasks` sub-commands.
+The `--no-wait` flag can be used with `install` and `remove` to indicate that snapctl should not block on the created change. Instead, snapctl will immediately return the change ID. This has similar semantics to `--no-wait` when used with `snap install/refresh`. This change ID should be used with the `is-ready` and `tasks` sub-commands. Note that `--no-wait` is not allowed to be run within a hook.
 
 The `is-ready` sub-command enables polling the given change until it has reached a terminal state. See `snapctl is-ready --help` for a detailed breakdown of the exit codes used.
 

--- a/docs/how-to-guides/snap-development/use-snapctl.md
+++ b/docs/how-to-guides/snap-development/use-snapctl.md
@@ -107,13 +107,11 @@ snapctl remove +<comp_name>
 If these commands are run from a {ref}`hook <reference-development-supported-snap-hooks>`, the components will be installed/removed after the hook itself has run if it ended successfully.
 
 ### Asynchronous Operation
-Installation and removal commands are run synchronously by default, however, if snapctl supports the asynchronous feature, the command may operate asynchronously. The latest version of snapd will always support the feature, but older versions of snapctl packaged within snaps may not. A handshake between the daemon and snapctl determines how waiting proceeds:
-- If both support the feature, and the `--no-wait` flag is passed, the change-id is returned immediately and the user polls `snapctl is-ready` to determine when
-the change has finished.
-- If both support the feature, and the `--no-wait` flag is not passed, the client will use is-ready internally to ensure the change completes before returning.
-- If snapctl does not support the feature, the daemon reverts to the existing polling approach internally.
+By default installation and removal commands are run synchronously and will block until the change is completed.
 
-To view all tasks associated with a change-id in the same snapctl context, the command `snapctl tasks` may be used, also aliased to `snapctl changes`. Optionally, the `--format` flag may be passed with the `json` argument to return the data as JSON rather than a tabular representation.
+To enable deeper insight of the change, the `--no-wait` flag can be passed. In this case, the change-id is returned immediately and the user can poll `snapctl is-ready` to determine when the change has finished.
+
+To view all tasks associated with a change-id in the same snapctl context, the command `snapctl tasks` may be used. Optionally, the `--format` flag may be passed with the `json` argument to return the data as JSON rather than a tabular representation.
 
 ## Health state
 

--- a/docs/how-to-guides/snap-development/use-snapctl.md
+++ b/docs/how-to-guides/snap-development/use-snapctl.md
@@ -106,15 +106,11 @@ snapctl remove +<comp_name>
 
 If these commands are run from a {ref}`hook <reference-development-supported-snap-hooks>`, the components will be installed/removed after the hook itself has run if it ended successfully.
 
-## snapctl commands
-
-From within a snap, the [snapctl](https://snapcraft.io/docs/using-snapctl) command can be used to install and remove components from an application, including snap hooks and component hooks. The commands for this are:
-
-$ snapctl install +<comp_name>
-
-$ snapctl remove +<comp_name>
-
-If these commands are run from a hook, the components will be installed/removed after the hook itself has run if it ended successfully.
+### Asynchronous Operation
+These commands are run synchronously by default, however, if snapctl supports the _async_ feature, then the `--no-wait` flag can be used to
+immediately return a change ID, which can then be polled with snapctl is-ready <change-id>. To view all change-ids associated with a snapctl
+context, the command `snapctl tasks` may be used. Optionally, the `--json` flag may be passed to return the data as JSON rather than a tabular
+representation.
 
 ## Health state
 

--- a/docs/how-to-guides/snap-development/use-snapctl.md
+++ b/docs/how-to-guides/snap-development/use-snapctl.md
@@ -107,10 +107,13 @@ snapctl remove +<comp_name>
 If these commands are run from a {ref}`hook <reference-development-supported-snap-hooks>`, the components will be installed/removed after the hook itself has run if it ended successfully.
 
 ### Asynchronous Operation
-These commands are run synchronously by default, however, if snapctl supports the _async_ feature, then the `--no-wait` flag can be used to
-immediately return a change ID, which can then be polled with snapctl is-ready <change-id>. To view all change-ids associated with a snapctl
-context, the command `snapctl tasks` may be used. Optionally, the `--json` flag may be passed to return the data as JSON rather than a tabular
-representation.
+Installation and removal commands are run synchronously by default, however, if snapctl supports the asynchronous feature, the command may operate asynchronously. The latest version of snapd will always support the feature, but older versions of snapctl packaged within snaps may not. A handshake between the daemon and snapctl determines how waiting proceeds:
+- If both support the feature, and the `--no-wait` flag is passed, the change-id is returned immediately and the user polls `snapctl is-ready` to determine when
+the change has finished.
+- If both support the feature, and the `--no-wait` flag is not passed, the client will use is-ready internally to ensure the change completes before returning.
+- If snapctl does not support the feature, the daemon reverts to the existing polling approach interally.
+
+To view all tasks associated with a change-id in the same snapctl context, the command `snapctl tasks` may be used, also aliased to `snapctl changes`. Optionally, the `--format` flag may be passed with the `json` argument to return the data as JSON rather than a tabular representation.
 
 ## Health state
 

--- a/docs/how-to-guides/snap-development/use-snapctl.md
+++ b/docs/how-to-guides/snap-development/use-snapctl.md
@@ -109,7 +109,7 @@ If these commands are run from a {ref}`hook <reference-development-supported-sna
 ### Asynchronous Operation
 By default, the `install` and `remove` sub-commands run synchronously and will block until the change they create is completed.
 
-The `--no-wait` flag can be used with `install` and `remove` to indicate that snapctl should not block on the created change. Instead, snapctl will immediately return the change ID. This has similar semantics to `--no-wait` when used with `snap install/refresh`. This change ID should be used with the `is-ready` and `tasks` sub-commands. Note that `--no-wait` is not allowed to be run within a hook.
+The `--no-wait` flag can be used with `install` and `remove` to indicate that snapctl should not block on the created change. Instead, snapctl will immediately return the change ID. This has similar semantics to `--no-wait` when used with `snap install/refresh`. This change ID should be used with the `is-ready` and `tasks` sub-commands. Note that `--no-wait` is not allowed to be used within a hook.
 
 The `is-ready` sub-command enables polling the given change until it has reached a terminal state. See `snapctl is-ready --help` for a detailed breakdown of the exit codes used.
 

--- a/docs/how-to-guides/snap-development/use-snapctl.md
+++ b/docs/how-to-guides/snap-development/use-snapctl.md
@@ -111,7 +111,7 @@ Installation and removal commands are run synchronously by default, however, if 
 - If both support the feature, and the `--no-wait` flag is passed, the change-id is returned immediately and the user polls `snapctl is-ready` to determine when
 the change has finished.
 - If both support the feature, and the `--no-wait` flag is not passed, the client will use is-ready internally to ensure the change completes before returning.
-- If snapctl does not support the feature, the daemon reverts to the existing polling approach interally.
+- If snapctl does not support the feature, the daemon reverts to the existing polling approach internally.
 
 To view all tasks associated with a change-id in the same snapctl context, the command `snapctl tasks` may be used, also aliased to `snapctl changes`. Optionally, the `--format` flag may be passed with the `json` argument to return the data as JSON rather than a tabular representation.
 

--- a/docs/how-to-guides/snap-development/use-snapctl.md
+++ b/docs/how-to-guides/snap-development/use-snapctl.md
@@ -109,13 +109,13 @@ If these commands are run from a {ref}`hook <reference-development-supported-sna
 ### Asynchronous Operation
 By default, the `install` and `remove` sub-commands run synchronously and will block until the change they create is completed.
 
-The --no-wait flag can be used with install and remove to indicate that snapctl should not block on the created change. Instead, snapctl will immediately return the change ID. This has similar semantics to --no-wait when used with snap install/refresh. This change ID should be used with the is-ready and tasks sub-commands.
+The `--no-wait` flag can be used with `install` and `remove` to indicate that snapctl should not block on the created change. Instead, snapctl will immediately return the change ID. This has similar semantics to `--no-wait` when used with `snap install/refresh`. This change ID should be used with the `is-ready` and `tasks` sub-commands.
 
-The is-ready sub-command enables polling the given change until it has reached a terminal state. See snapctl is-ready --help for a detailed breakdown of the exit codes used.
+The `is-ready` sub-command enables polling the given change until it has reached a terminal state. See `snapctl is-ready --help` for a detailed breakdown of the exit codes used.
 
-The tasks sub-command prints detailed information about the given change. This includes information such as the exact state of the change and the progress of individual tasks within the change. Provide the --format=json argument to receive JSON output, rather than the default tabular representation.
+The `tasks` sub-command prints detailed information about the given change. This includes information such as the exact state of the change and the progress of individual tasks within the change. Provide the `--format=json` argument to receive JSON output, rather than the default tabular representation.
 
-Note that both snapctl is-ready and snapctl tasks can only be used with changes that were created by the snap in which they are being invoked. Arbitrary changes on the system cannot be introspected via these sub-commands.
+Note that both `snapctl is-ready` and `snapctl tasks` can only be used with changes that were created by the snap in which they are being invoked. Arbitrary changes on the system cannot be introspected via these sub-commands.
 
 ## Health state
 


### PR DESCRIPTION
This PR contains information on the release of the following PRs:

- Async snapctl functionality
- Is-ready sub-command and rate limiting/authentication.
- --no-wait flag for asynchronous monitoring.
- snapctl tasks/changes for retrieving all change information.
- snap tasks for maintaining API between snapctl and snap commands.

From SNAPDENG-36723