### PR TITLE
docs: fix snap refresh --amend typo

### DIFF
--- a/docs/explanation/snap-development/install-modes.md
+++ b/docs/explanation/snap-development/install-modes.md
@@ -28,7 +28,7 @@ The `--dangerous` argument will install a local snap without validating or check
 
 This option is useful when testing snaps shared through a trusted channel, and for testing snaps built locally, before eventually being published to the store.
 
-The `snap refresh --ammend` command can be used to replace a locally installed snap with an identically named snap on the store.
+The `snap refresh --amend` command can be used to replace a locally installed snap with an identically named snap on the store.
 
 ## Developer mode
 

--- a/docs/how-to-guides/manage-snaps/manage-updates.md
+++ b/docs/how-to-guides/manage-snaps/manage-updates.md
@@ -231,7 +231,7 @@ qt551          5.5                        30    keshavnrj     -
 
 ## Locally installed snaps
 
-The `snap refresh --ammend` command can be used to replace a locally installed snap with an identically named snap on the store.
+The `snap refresh --amend` command can be used to replace a locally installed snap with an identically named snap on the store.
 
 ## Monitor changes
 


### PR DESCRIPTION
Fixes #314

## Summary
- correct `snap refresh --ammend` to `snap refresh --amend`
- update both affected documentation pages so the command stays consistent

## Testing
- verified the docs diffs and ran `git diff --check`
