### PR TITLE
fix: correct typo 'hannels:' -> 'channels:' in snap info output

### DIFF
--- a/docs/explanation/how-snaps-work/channels-and-tracks.md
+++ b/docs/explanation/how-snaps-work/channels-and-tracks.md
@@ -36,7 +36,7 @@ Tracks are listed in the *channels* section of the output from the `snap info` c
 ```
 $ snap info firefox
 [...]
-hannels:
+channels:
   latest/stable:    149.0.2-1     2026-04-08 (8107) 287MB -
   latest/candidate: 150.0-1       2026-04-16 (8172) 288MB -
   latest/beta:      150.0b10-1    2026-04-15 (8166) 288MB -


### PR DESCRIPTION
## Summary

Fixes a typo in `docs/explanation/how-snaps-work/channels-and-tracks.md` where the `snap info` example output shows `hannels:` instead of `channels:` — the opening "c" was missing.

## Change

- **Before:** `hannels:`
- **After:** `channels:`

Closes #330