### PR TITLE
Document behaviour of concurrent confdb accesses

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -316,3 +316,4 @@ Yaru
 Yocto
 Zorin
 zsh
+databag

--- a/docs/how-to-guides/manage-snaps/configure-snaps-with-confdb.md
+++ b/docs/how-to-guides/manage-snaps/configure-snaps-with-confdb.md
@@ -325,6 +325,10 @@ $ cat /snap/reader-snap/common/ssid
 acme-some-ssid
 ```
 
+Note that concurrent accesses may block if they would result in writes running concurrently with another access. If any access is blocked, subsequent accesses will also be queued to ensure that they are run in order.
+
+For example, if there is a read ongoing and a write is requested, the write will be blocked. A new read would then also be queued and only run after the write, even though reads are normally run concurrently. This ensures that a stream of reads cannot starve a write access.
+
 ## Getting secret data
 *From snapd version 2.76+*
 

--- a/docs/how-to-guides/snap-development/use-snapctl.md
+++ b/docs/how-to-guides/snap-development/use-snapctl.md
@@ -83,6 +83,10 @@ $ snapctl get --view :setup-wifi routes --with to=default
 }
 ```
 
+Concurrent accesses may block if they would result in writes running concurrently with another access. If any access is blocked, subsequent accesses will also be queued to ensure that they are run in order.
+
+For example, if there is a read ongoing and a write is requested, the write will be blocked. A new read would then also be queued and only run after the write, even though reads are normally run concurrently. This ensures that a stream of reads cannot starve a write access.
+
 For further information on confdb, see {ref}`Configure snaps with confdb <how-to-guides-manage-snaps-configure-snaps-with-confdb>` and {ref}`Confdb configuration mechanism <explanation-how-snaps-work-confdb-configuration-mechanism>`.
 
 ## Components


### PR DESCRIPTION
Documents the behaviour of concurrent confdb accesses in the `snapctl` confdb section and the how-to guide.

https://warthogs.atlassian.net/browse/SNAPDENG-35595