### PR TITLE
references: document snap exit codes

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -213,6 +213,7 @@ repo
 Repology
 requesters
 resampling
+retryable
 roadmapped
 Rockcraft
 RODatabase

--- a/docs/reference/exit-codes.md
+++ b/docs/reference/exit-codes.md
@@ -7,7 +7,7 @@ diagnosing failures.
 |:---|:---|:---|
 | 0   | Success | The command completed without error. |
 | 1   | General error | The command failed for a reason not covered by a more specific exit code. |
-| 10  | Retriable error | Another snap operation is in progress resulting in a `snap-change-conflict`. Wait for it to finish and try again. |
+| 10  | Retryable error | Another snap operation is in progress resulting in a `snap-change-conflict`. Wait for it to finish and try again. |
 | 20  | Build error | `mksquashfs` failed when building a snap (e.g. during `snap pack`). |
 | 46  | Internal error | The snap app binary dispatch failed. Either the `/snap/bin/` symlink could not be resolved, or the snap app could not be run. |
 | 64  | Usage error | Invalid flags, arguments, or an unknown command was provided. |

--- a/docs/reference/exit-codes.md
+++ b/docs/reference/exit-codes.md
@@ -1,0 +1,13 @@
+(reference-operations-exit-codes)=
+# Exit codes
+The `snap` command uses the following exit codes. These are useful when scripting `snap` operations or
+diagnosing failures.
+
+| Code | Meaning | Description |
+|:---|:---|:---|
+| 0   | Success | The command completed without error. |
+| 1   | General error | The command failed for a reason not covered by a more specific exit code. |
+| 10  | Retryable error | Another snap operation is in progress resulting in a `snap-change-conflict`. Wait for it to finish and try again. |
+| 20  | Build error | `mksquashfs` failed when building a snap (e.g. during `snap pack`). |
+| 46  | Internal error | The snap app binary dispatch failed. Either the `/snap/bin/` symlink could not be resolved, or the snap app could not be run. |
+| 64  | Usage error | Invalid flags, arguments, or an unknown command was provided. |

--- a/docs/reference/exit-codes.md
+++ b/docs/reference/exit-codes.md
@@ -7,7 +7,7 @@ diagnosing failures.
 |:---|:---|:---|
 | 0   | Success | The command completed without error. |
 | 1   | General error | The command failed for a reason not covered by a more specific exit code. |
-| 10  | Retryable error | Another snap operation is in progress resulting in a `snap-change-conflict`. Wait for it to finish and try again. |
+| 10  | Retriable error | Another snap operation is in progress resulting in a `snap-change-conflict`. Wait for it to finish and try again. |
 | 20  | Build error | `mksquashfs` failed when building a snap (e.g. during `snap pack`). |
 | 46  | Internal error | The snap app binary dispatch failed. Either the `/snap/bin/` symlink could not be resolved, or the snap app could not be run. |
 | 64  | Usage error | Invalid flags, arguments, or an unknown command was provided. |

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -51,3 +51,4 @@ System architecture <system-architecture>
 Interfaces <interfaces/index>
 Administration <administration/index>
 Snap development <development/index>
+Exit codes <exit-codes>

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -17,6 +17,7 @@ Details that help with the day-to-day operations of working with snaps.
 * {ref}`Interfaces <ref-index_interfaces>`: Every interface alongside their most important attributes.
 * {ref}`Snap system architecture <reference-operations-system-architecture>`: What snapd uses to manage confinement and security. 
 * {ref}`System options <reference-operations-system-options>`: Configurations options for the system and native snap devices.
+* {ref}`Exit codes <reference-operations-exit-codes>`: Exit codes returned by the `snap` command.
 
 ## Administration
 


### PR DESCRIPTION
Adds documentation for the snap command's exit codes.

Tracked with [SNAPDENG-34132](https://warthogs.atlassian.net/browse/SNAPDENG-34132?atlOrigin=eyJpIjoiZWVjMDYzNDlhYmJjNDE4Y2FiMDE5Yjk2ZjcxM2I0NjIiLCJwIjoiaiJ9)

[SNAPDENG-34132]: https://warthogs.atlassian.net/browse/SNAPDENG-34132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ