### PR TITLE
Improve heading choice in release notes

### DIFF
--- a/docs/reference/release-notes.md
+++ b/docs/reference/release-notes.md
@@ -51,7 +51,8 @@ We greatly appreciate your contributions and support!
 
 We’re pleased to share that Snapd 2.74 snap is available for testing in the beta channel.
 
-### New in snapd 2.74
+### **Highlights**
+
 * FDE: use new activation API from secboot
 * FDE: use activation API also with non keydata keys
 * FDE: ignore internal recovery key expiration during install

--- a/docs/reference/release-notes.md
+++ b/docs/reference/release-notes.md
@@ -51,7 +51,7 @@ We greatly appreciate your contributions and support!
 
 We’re pleased to share that Snapd 2.74 snap is available for testing in the beta channel.
 
-# New in snapd 2.74
+### New in snapd 2.74
 * FDE: use new activation API from secboot
 * FDE: use activation API also with non keydata keys
 * FDE: ignore internal recovery key expiration during install


### PR DESCRIPTION
This aligns better with the heading levels and prevents "New in snapd 2.74" appearing in the sidebar.