### PR TITLE
d/r/development: document new desktop related environment variables added in snapd 2.77

### DIFF
--- a/docs/reference/development/environment-variables.md
+++ b/docs/reference/development/environment-variables.md
@@ -189,7 +189,7 @@ The name of the application being run, as specified in the `snapcraft.yaml`.
 
 Only set when running an application command.
 
-Typical value: `cmd`
+Typical value: `my-snap-app`
 
 Requires _snapd_ 2.77+.
 
@@ -207,9 +207,11 @@ Requires _snapd_ 2.77+.
 
 The absolute path to the application's installed desktop file.
 
-Only set when running an application that has an associated desktop file on disk.
+Only set when running an application that has an associated desktop file on disk. The actual value depends on whether `common-id` is defined, or whether `desktop-file-ids` attribute is added to the `desktop` interface plug, and presence of matching desktop files. 
 
-Typical value: `/var/lib/snapd/desktop/applications/org.example.Foo.desktop`
+Typical values:
+- `/var/lib/snapd/desktop/applications/my-snap-name_my-snap-app.desktop`
+- `/var/lib/snapd/desktop/applications/org.example.Foo.desktop`
 
 Requires _snapd_ 2.77+.
 

--- a/docs/reference/development/environment-variables.md
+++ b/docs/reference/development/environment-variables.md
@@ -207,8 +207,6 @@ Requires _snapd_ 2.77+.
 
 The absolute path to the application's installed desktop file.
 
-Only set when running an application that has an associated desktop file on disk. The actual value depends on whether `common-id` is defined, or whether `desktop-file-ids` attribute is added to the `desktop` interface plug, and presence of matching desktop files. 
-
 Typical values:
 - `/var/lib/snapd/desktop/applications/my-snap-name_my-snap-app.desktop`
 - `/var/lib/snapd/desktop/applications/org.example.Foo.desktop`

--- a/docs/reference/development/environment-variables.md
+++ b/docs/reference/development/environment-variables.md
@@ -207,6 +207,8 @@ Requires _snapd_ 2.77+.
 
 The absolute path to the application's installed desktop file.
 
+Only set when running an application that has an associated desktop file on disk. The value depends on the use of the `common-id` property, or the `desktop-file-ids` attribute in the `desktop` interface plug.
+
 Typical values:
 - `/var/lib/snapd/desktop/applications/my-snap-name_my-snap-app.desktop`
 - `/var/lib/snapd/desktop/applications/org.example.Foo.desktop`

--- a/docs/reference/development/environment-variables.md
+++ b/docs/reference/development/environment-variables.md
@@ -183,6 +183,46 @@ The vanilla `HOME` environment variable before snapd-induced remapping, refer to
 
 Requires _snapd_ 2.46+.
 
+### <pre>SNAP_APP_NAME</pre>
+
+The name of the application being run, as specified in the `snapcraft.yaml`.
+
+Only set when running an application command.
+
+Typical value: `cmd`
+
+Requires _snapd_ 2.77+.
+
+### <pre>SNAP_APP_COMMON_ID</pre>
+
+The common identifier of the application, as specified by the `common-id` field in `snapcraft.yaml`. This is typically a reverse-DNS identifier used to associate the application with its desktop entry.
+
+Only set when running an application that defines a `common-id`.
+
+Typical value: `org.example.Foo`
+
+Requires _snapd_ 2.77+.
+
+### <pre>SNAP_APP_DESKTOP_FILE</pre>
+
+The absolute path to the application's installed desktop file.
+
+Only set when running an application that has an associated desktop file on disk.
+
+Typical value: `/var/lib/snapd/desktop/applications/org.example.Foo.desktop`
+
+Requires _snapd_ 2.77+.
+
+### <pre>SNAP_APP_BUS_NAME</pre>
+
+The D-Bus bus name the application is allowed to own, as specified by the `bus-name` field in `snapcraft.yaml`.
+
+Only set when running an application that defines a `bus-name`.
+
+Typical value: `org.example.Foo`
+
+Requires _snapd_ 2.77+.
+
 ## Generic variables
 
 ### <pre>HOME</pre>


### PR DESCRIPTION
Update the documentation to mention new environment variables added in snapd 2.77:
 - SNAP_APP_NAME
 - SNAP_APP_COMMON_ID
 - SNAP_APP_DESKTOP_FILE
 - SNAP_APP_BUS_NAME

See https://github.com/canonical/snapd/pull/16016