### PR TITLE
openapi: fix assertion to new-model in /v2/model

### DIFF
--- a/docs/_html_extra/reference/development/snapd-rest-api/openapi.json
+++ b/docs/_html_extra/reference/development/snapd-rest-api/openapi.json
@@ -5488,10 +5488,10 @@
                 "description": "Used for online remodeling. The request body is a JSON object\ncontaining the new model assertion.",
                 "type": "object",
                 "required": [
-                  "assertion"
+                  "new-model"
                 ],
                 "properties": {
-                  "assertion": {
+                  "new-model": {
                     "type": "string",
                     "description": "A string containing the full, signed model assertion.",
                     "example": "type: model\nauthority-id: generic\nseries: 16\nbrand-id: generic\nmodel: generic-classic\nclassic: true\ntimestamp: 2025-10-03T10:40:00.0Z\nsign-key-sha3-384: d-JcZF9nD9eBw7bwMnH61x-bklnQOhQud1Is6o_cn2wTj8EYDi9musrIT9z2MdAa\nAcLBXAQAAQ[...]\n"
@@ -5502,7 +5502,7 @@
                 "remodelRequest": {
                   "summary": "A typical JSON request to set a new model.",
                   "value": {
-                    "assertion": "type: model\nauthority-id: generic\nseries: 16\nbrand-id: generic\nmodel: generic-classic\nclassic: true\ntimestamp: 2025-10-03T10:40:00.0Z\nsign-key-sha3-384: d-JcZF9nD9eBw7bwMnH61x-bklnQOhQud1Is6o_cn2wTj8EYDi9musrIT9z2MdAa\nAcLBXAQAAQ[...]"
+                    "new-model": "type: model\nauthority-id: generic\nseries: 16\nbrand-id: generic\nmodel: generic-classic\nclassic: true\ntimestamp: 2025-10-03T10:40:00.0Z\nsign-key-sha3-384: d-JcZF9nD9eBw7bwMnH61x-bklnQOhQud1Is6o_cn2wTj8EYDi9musrIT9z2MdAa\nAcLBXAQAAQ[...]"
                   }
                 }
               }

--- a/docs/_html_extra/reference/development/snapd-rest-api/openapi.yaml
+++ b/docs/_html_extra/reference/development/snapd-rest-api/openapi.yaml
@@ -1588,9 +1588,9 @@ paths:
                 containing the new model assertion.
               type: object
               required:
-                - assertion
+                - new-model
               properties:
-                assertion:
+                new-model:
                   type: string
                   description: A string containing the full, signed model assertion.
                   example: |
@@ -1607,7 +1607,7 @@ paths:
               remodelRequest:
                 summary: A typical JSON request to set a new model.
                 value:
-                  assertion: |-
+                  new-model: |-
                     type: model
                     authority-id: generic
                     series: 16


### PR DESCRIPTION
Change the `/v2/model` POST example JSON to use the `new-model` field instead of `assertion`, as this is what is expected by snapd for API calls.

Reference: https://github.com/canonical/snapd/blob/49b363c11dc2c79213aa466d9898dc3bd779287f/daemon/api_model.go#L67

Fixes #367 