### PR TITLE
docs: add note about breaking changes in confdb-schemas

### DIFF
--- a/docs/explanation/how-snaps-work/confdb-configuration-mechanism.md
+++ b/docs/explanation/how-snaps-work/confdb-configuration-mechanism.md
@@ -204,7 +204,7 @@ If there is a change in the configuration data’s layout, only the assertion ne
       access: read
 ```
 
-```{note}
+```{warning}
 The configuration namespace should be considered carefully up front. While new confdb views can be added and existing ones can be extended, devices in the field may be running older snap versions that still depend on the existing namespace and views. Removing or renaming request paths, views, or schemas can therefore break those older snaps, making "outdated" namespaces difficult to retire safely.
 ```
 

--- a/docs/explanation/how-snaps-work/confdb-configuration-mechanism.md
+++ b/docs/explanation/how-snaps-work/confdb-configuration-mechanism.md
@@ -204,6 +204,10 @@ If there is a change in the configuration data’s layout, only the assertion ne
       access: read
 ```
 
+```{note}
+The configuration namespace should be considered carefully up front. While new confdb views can be added and existing ones can be extended, devices in the field may be running older snap versions that still depend on the existing namespace and views. Removing or renaming request paths, views, or schemas can therefore break those older snaps, making "outdated" namespaces difficult to retire safely.
+```
+
 (ref-confdb-configuration-mechanism_interface-plugs)=
 ## Interface Plugs
 


### PR DESCRIPTION
Adds a note warning users that removing or changing request paths and views is fraught since snaps using those cannot guaranteed to be upgraded.

https://warthogs.atlassian.net/browse/SNAPDENG-36973