### PR TITLE
docs: apply SD247 standard to confdb docs

### DIFF
--- a/docs/explanation/how-snaps-work/confdb-configuration-mechanism.md
+++ b/docs/explanation/how-snaps-work/confdb-configuration-mechanism.md
@@ -46,16 +46,16 @@ The following is almost the simplest confdb-schema assertion that could be defin
 ```yaml
 type: confdb-schema
 account-id: system
-name: snap-status
+name: snaps
 
 [...]
 
 views:
-  observe:
+  state:
     rules:
       -
       request: snaps.firefox.status
-      storage: snaps.firefox.status
+      storage: v1.snaps.firefox.status
       access: read
 
 [...]
@@ -64,7 +64,7 @@ views:
 This above configuration could be accessed as follows:
 
 ```
-$ snap get system/snap-status/observe snaps.firefox.status
+$ snap get system/snaps/state snaps.firefox.status
 enabled
 ```
 
@@ -79,7 +79,7 @@ Instead of enumerating every possible combination, we can use a placeholder to m
     rules:
       -
       request: snaps.{name}.status
-      storage: snaps.{name}.status
+      storage: v1.snaps.{name}.status
       access: read
 [...]
 ```
@@ -87,10 +87,10 @@ Instead of enumerating every possible combination, we can use a placeholder to m
 This enables the snap name to be dynamically mapped into the query:
 
 ```
-$ snap get system/snap-status/observe snaps.firefox.status
+$ snap get system/snaps/state snaps.firefox.status
 enabled
 
-$ snap get system/snap-status/observe snaps.spotify.status
+$ snap get system/snaps/state snaps.spotify.status
 disabled
 ```
 
@@ -101,10 +101,11 @@ To add more configuration paths for snaps, either add more rules or, if possible
 ```yaml
 [...]
 
+  state:
     rules:
       -
       request: snaps.{name}
-      storage: snaps.{name}
+      storage: v1.snaps.{name}
       access: read
       content:
         - storage: status
@@ -120,13 +121,13 @@ This example only provides a storage path. When omitted, the request path is ass
 As requests are matched on *prefixes* of the request paths in view rules, it’s possible to provide a prefix path to \`snap get\` and to obtain an aggregate result:
 
 ```
-$ snap get system/snap-status/observe snaps.firefox.status
+$ snap get system/snaps/state snaps.firefox.status
 enabled
 
-$ snap get system/snap-status/observe snaps.spotify.revision
+$ snap get system/snaps/state snaps.spotify.revision
 7
 
-$ snap get system/snap-status/observe snaps
+$ snap get system/snaps/state snaps
 {
   "firefox": {
     "status": "enabled"
@@ -146,16 +147,16 @@ All the rule mappings defined above have the same “request” and “storage�
 ...
     rules:
       -
-      request: snaps.{name}
-      storage: snaps.{name}
-      access: read
-      content:
-        - storage: status
-        - storage: revision
+        request: snaps.{name}
+        storage: v1.snaps.{name}
+        access: read
+        content:
+          - storage: status
+          - storage: revision
       -
-      request: system-status
-      storage: snaps.snapd.status
-      access: read
+        request: system-status
+        storage: v1.snaps.snapd.status
+        access: read
 ```
 
 This maps an already exposed path (snaps.snapd.status) under a new request path, allowing us to query `system-status` directly.
@@ -163,7 +164,7 @@ This maps an already exposed path (snaps.snapd.status) under a new request path,
 In the future, if a new path was intended to provide the value for `system-status`, we would only need to modify the mapping.
 
 ```
-$ snap get system/snap-status/observe
+$ snap get system/snaps/state
 {
   "snaps": {
     "firefox": {
@@ -191,17 +192,17 @@ If there is a change in the configuration data’s layout, only the assertion ne
 ...
     rules:
       -
-      request: snaps.{name}.status
-      storage: statuses.{name}
-      access: read
+        request: snaps.{name}.status
+        storage: v1.statuses.{name}
+        access: read
       -
-      request: snaps.{name}.revision
-      storage: revision.{name}
-      access: read
+        request: snaps.{name}.revision
+        storage: v1.revisions.{name}
+        access: read
       -
-      request: system-status
-      storage: status.snapd
-      access: read
+        request: system-status
+        storage: v1.statuses.snapd
+        access: read
 ```
 
 ```{warning}
@@ -211,14 +212,14 @@ The configuration namespace should be considered carefully up front. While new c
 (ref-confdb-configuration-mechanism_interface-plugs)=
 ## Interface Plugs
 
-Snaps can use the {ref}`confdb interface <interfaces-confdb>` to express their interest in accessing a view through the plug stanza in their snapcraft.yaml (then snap.yaml). For example, a snap wishing to access the same `observe` view would declare it as:
+Snaps can use the {ref}`confdb interface <interfaces-confdb>` to express their interest in accessing a view through the plug stanza in their snapcraft.yaml (then snap.yaml). For example, a snap wishing to access the same `state` view would declare it as:
 
 ```yaml
 plugs:
-  observe-status:
+  snaps-state:
     interface: confdb
     account: system
-    view: snap-status/observe
+    view: snaps/state
 ```
 
 If the snap publisher signed the confdb assertion, the confdb interface will be auto-connected. Otherwise, the plug must be connected to the `:confdb` slot manually.
@@ -226,12 +227,11 @@ If the snap publisher signed the confdb assertion, the confdb interface will be 
 The snap can then refer to this interface plug when accessing confdb with the `snapctl` commands. It must also use the `--view` flag to signal this as a confdb request:
 
 ```
-$ snapctl set --view :observe-status snaps.firefox.status=enabled
-$ snapctl get --view :observe-status snaps.firefox.status
+$ snapctl get --view :snaps-state snaps.firefox.status
 enabled
 ```
 
-Confdb supports the same commands and options as the {ref}`original configuration mechanism <how-to-guides-work-with-snaps-configure-snaps>`. This includes unsetting data using `snapctl --view unset ...` or by using `snapctl --view set` with a `\!` prefixed to the request path.
+Confdb supports the same commands and options as the {ref}`original configuration mechanism <how-to-guides-work-with-snaps-configure-snaps>`. This includes unsetting data using `snapctl unset --view ...` or by using `snapctl set --view` with a `\!` prefixed to the request path.
 
 ### Custodians
 

--- a/docs/how-to-guides/manage-snaps/configure-snaps-with-confdb.md
+++ b/docs/how-to-guides/manage-snaps/configure-snaps-with-confdb.md
@@ -52,19 +52,25 @@ For example:
         "password": {
           "type": "string",
           "pattern": "^[\w~!@#\$%\^&-\+=\;:,\.\/\?]{8,63}$"
+        }
       },
-    },
       "schema": {
-        "wifi": {
+        "v1": {
           "schema": {
-            "psk": "${password}",
-            "ssid": "string",
-            "state": {
-              "type": "string",
-              "choices": [
-                "up",
-                "down"
-              ]
+            "wifi": {
+              "values": {
+                "schema": {
+                  "psk": "${password}",
+                  "ssid": "string",
+                  "state": {
+                    "type": "string",
+                    "choices": [
+                      "up",
+                      "down"
+                    ]
+                  }
+                }
+              }
             }
           }
         }
@@ -73,7 +79,7 @@ For example:
   }
 ```
 
-The above schema describes three configuration paths: an SSID, a password and a connection state.
+The above schema describes three fields within each Wi-Fi entry: an SSID, a password and a connection state.
 
 Snapd expects the storage schema to conform to a very precise format, using 2 spaces for indentation and sorting map entries. Both Python 3’s `json.dump` and Golang’s `json.MarshalIndent` can be used to produce this format. `jq -S` can also be used to sort the schema. It’s useful to keep the storage schema in its own file so we can modify it over time.
 
@@ -83,10 +89,10 @@ See [confdb-schema types](https://documentation.ubuntu.com/core/reference/assert
 
 Now let’s create some view rules to access confdb.
 
-In our example, we’ll use one snap to configure the network and another to access it, which means we need two views: `configure-wifi` and `access-wifi`.
+In our example, we'll use one snap to configure the network and another to access it, which means we need two views: `wifi-admin` and `wifi-state`.
 
-* `configure-wifi` exposes parameters and allows them to be set.
-* `access-wifi` allows the snap to list Wi-Fi connections and read SSID and state information (e.g., up, down).
+* `wifi-admin` exposes parameters and allows them to be set.
+* `wifi-state` allows the snap to list Wi-Fi connections and read SSID and state information (e.g., up, down).
 
 Both of these can be defined as follows:
 
@@ -98,25 +104,25 @@ name:         network
 summary:      Configure network parameters
 timestamp:    2025-04-02T19:31:32Z
 views:
-  configure-wifi:
+  wifi-admin:
     summary: Configure Wi-Fi networks
     rules:
       -
       request: "{name}.ssid"
-      storage: "wifi.{name}.ssid"
+      storage: "v1.wifi.{name}.ssid"
       -
       request: "{name}.password"
-      storage: "wifi.{name}.psk"
+      storage: "v1.wifi.{name}.psk"
       -
       request: "{name}.state"
-      storage: "wifi.{name}.state"
+      storage: "v1.wifi.{name}.state"
 
-  access-wifi:
+  wifi-state:
     summary: List and read Wi-Fi SSIDs
     rules:
       -
       request: "{name}"
-      storage: "wifi.{name}"
+      storage: "v1.wifi.{name}"
       access: read
       content:
         -
@@ -146,23 +152,23 @@ The end result should look something like the following:
 account-id: <account-id>
 name: network
 views:
-  configure-wifi:
+  wifi-admin:
     rules:
       -
         request: "{name}.ssid"
-        storage: "wifi.{name}.ssid"
+        storage: "v1.wifi.{name}.ssid"
       -
         request: "{name}.password"
-        storage: "wifi.{name}.psk"
+        storage: "v1.wifi.{name}.psk"
       -
         request: "{name}.state"
-        storage: "wifi.{name}.state"
+        storage: "v1.wifi.{name}.state"
 
-  access-wifi:
+  wifi-state:
     rules:
       -
         request: "{name}"
-        storage: "wifi.{name}"
+        storage: "v1.wifi.{name}"
         access: read
         content:
           -
@@ -180,14 +186,18 @@ body: |-
         }
       },
       "schema": {
-        "wifi": {
-          "values": {
-            "schema": {
-              "psk": "${password}",
-              "ssid": "string",
-              "state": {
-                "choices": ["up", "down"],
-                "type":"string"
+        "v1": {
+          "schema": {
+            "wifi": {
+              "values": {
+                "schema": {
+                  "psk": "${password}",
+                  "ssid": "string",
+                  "state": {
+                    "choices": ["up", "down"],
+                    "type": "string"
+                  }
+                }
               }
             }
           }
@@ -219,10 +229,10 @@ The first snap will configure the Wi-Fi network to be used, so let’s configure
 
 ```yaml
 plugs:
-  configure-wifi:
+  network-wifi-admin:
     interface: confdb
     account: <account-id>
-    view: network/configure-wifi
+    view: network/wifi-admin
     role: custodian
 ```
 
@@ -234,15 +244,15 @@ In this case, the custodian snap will only define the `change-view-<plug>`, whic
 
 As an example, we’ll say that the SSID must be prefixed with our company’s name: “Acme”. The configuration can be set by the administrator using {ref}`snap set <how-to-guides-work-with-snaps-configure-snaps>` or by any other snap with access to that view, so it’s the custodian snap’s responsibility to enforce the prefix.
 
-Our `change-view-configure-wifi` hook looks like this:
+Our `change-view-network-wifi-admin` hook looks like this:
 
 ```shell
 #!/bin/bash -xe
 
 # prefix the SSID with "acme", if not already present
-value=$(snapctl get --view :configure-wifi acme.ssid)
+value=$(snapctl get --view :network-wifi-admin acme.ssid)
 if [[ "$?" -eq 0 && "$value" != acme-* ]]; then
-  snapctl set --view :configure-wifi acme.ssid="acme-$value"
+  snapctl set --view :network-wifi-admin acme.ssid="acme-$value"
 fi
 ```
 
@@ -254,10 +264,10 @@ Now we’ll create a snap that will read the configuration. Its plug will refere
 
 ```yaml
 plugs:
-  access-wifi:
+  network-wifi-state:
     interface: confdb
     account: <account-id>
-    view: network/access-wifi
+    view: network/wifi-state
 ```
 
 Non-custodian snaps can only define an `observe-view-<plug>` hook, which allows them to be notified when the confdb-schema referenced by that plug has been used to modify data.
@@ -266,7 +276,7 @@ Non-custodian snaps can only define an `observe-view-<plug>` hook, which allows 
 #!/bin/sh -xe
 
 # read the new SSID and store it somewhere
-new_ssid=$(snapctl get --view :access-wifi acme.ssid)
+new_ssid=$(snapctl get --view :network-wifi-state acme.ssid)
 echo "$new_ssid" >> "$SNAP_COMMON"/ssid
 ```
 
@@ -278,8 +288,8 @@ Note that when a snap is published by the same account ID as the assertion, the 
 
 ```shell
 snap install custodian-snap reader-snap
-snap connect custodian-snap:configure-wifi
-snap connect reader-snap:access-wifi
+snap connect custodian-snap:network-wifi-admin
+snap connect reader-snap:network-wifi-state
 ```
 
 ## Setting data
@@ -288,37 +298,37 @@ Now we’re ready to start setting data, we’ll use `snap run --shell` to mimic
 
 ```shell
 $ sudo snap run --shell custodian-snap.sh
-# snapctl set --view :configure-wifi acme.ssid=some-ssid acme.password=super-secret
+# snapctl set --view :network-wifi-admin acme.ssid=some-ssid acme.password=super-secret
 # exit
 
 $ sudo snap run --shell reader-snap.sh
-# snapctl get --view :access-wifi acme.ssid
+# snapctl get --view :network-wifi-state acme.ssid
 acme-some-ssid
 # exit
 
-$ snap get <account-id>/network/access-wifi acme.ssid
+$ snap get <account-id>/network/wifi-state acme.ssid
 acme-some-ssid
 ```
 
-As expected, the `change-view-configure-wifi` hook was invoked when `custodian-snap` modified the SSID and prefixed the value with “acme”.
+As expected, the `change-view-network-wifi-admin` hook was invoked when `custodian-snap` modified the SSID and prefixed the value with "acme".
 
 We were also able to read the same value from both another connected snap and through the snapd API using `snap get`.
 
-We can also check that the `reader-snap`’s `observe-view-access-wifi` hook was invoked when the SSID was changed and that it saved the new value in SNAP\_COMMON:
+We can also check that the `reader-snap`'s `observe-view-network-wifi-state` hook was invoked when the SSID was changed and that it saved the new value in SNAP\_COMMON:
 
 ```shell
 $ snap changes
 ID   Status  Spawn               Ready               Summary
-123  Done    today at ...        today at ...        Set confdb through "<account-id>/network/configure-wifi"
+123  Done    today at ...        today at ...        Set confdb through "<account-id>/network/wifi-admin"
 ...
 
 $ snap change 123
 Status  Spawn  Ready  Summary
 Done    ...    ...    Clears the ongoing confdb transaction from state (on error)
-Done    ...    ...    Run hook change-view-manage-wifi of snap "custodian-snap"
-Done    ...    ...    Run hook observe-view-manage-wifi of snap "test-snap"
-Done    ...    ...    Commit changes to confdb (NI7Jstuu8gffcoXr02i1kYt898p6Co0A/network/wifi-setup)
-Done   ...    ...   Clears the ongoing confdb transaction from state
+Done    ...    ...    Run hook change-view-network-wifi-admin of snap "custodian-snap"
+Done    ...    ...    Run hook observe-view-network-wifi-state of snap "reader-snap"
+Done    ...    ...    Commit changes to confdb (<account-id>/network/wifi-admin)
+Done    ...    ...    Clears the ongoing confdb transaction from state
 
 
 $ cat /snap/reader-snap/common/ssid
@@ -351,18 +361,18 @@ Assuming we have then recreated and signed the assertion, we can see that read a
 
 ```console
 $ sudo snap run --shell custodian-snap.sh
-# snapctl get --view :configure-wifi acme.password
+# snapctl get --view :network-wifi-admin acme.password
 super-secret
 # exit
 
 $ snap run --shell custodian-snap.sh
-# snapctl get --view :configure-wifi acme.password
-cannot get "acme.password" through <account-id>/network/configure-wifi: unauthorized access
+# snapctl get --view :network-wifi-admin acme.password
+cannot get "acme.password" through <account-id>/network/wifi-admin: unauthorized access
 # exit
 
-$ sudo snap get <account-id>/network/configure-wifi acme.password
+$ sudo snap get <account-id>/network/wifi-admin acme.password
 super-secret
 
-$ snap get <account-id>/network/configure-wifi acme.password
+$ snap get <account-id>/network/wifi-admin acme.password
 access denied (try with sudo)
 ```

--- a/docs/reference/interfaces/confdb-interface.md
+++ b/docs/reference/interfaces/confdb-interface.md
@@ -9,10 +9,10 @@ See the {ref}`Confdb configuration mechanism <explanation-how-snaps-work-confdb-
 
 ```
 [...]
- read-sensor-params:
+ sensors-sensor1-state:
   interface: confdb
   account: acme
-  view: sensors/read-sensor1-parameters
+  view: sensors/sensor1-state
 ```
 
 ```{warning}


### PR DESCRIPTION
Renames views to the `<noun>-admin/state` pattern. Adds a v1 prefix to storage paths. Rename interface plugs and hooks to follow `<schema>-<view-name>` convention.
The spec in question: https://docs.google.com/document/d/1zMqIwwvXSv73mZ2lmeknn0cTsIbMug2AsJ_7qHfGi0w/edit?tab=t.0