### PR TITLE
docs: document default values for confdb

### DIFF
--- a/docs/how-to-guides/manage-snaps/configure-snaps-with-confdb.md
+++ b/docs/how-to-guides/manage-snaps/configure-snaps-with-confdb.md
@@ -341,14 +341,14 @@ For example, if there is a read ongoing and a write is requested, the write will
 
 ## Default values
 
-Confdb has no schema-level mechanism for declaring default values. If no value has been set for a requested path, `snap get` returns an error. You can supply a fallback with `--default`:
+Confdb has no schema-level mechanism for declaring default values, but both `snap` and `snapctl` allow supplying a fallback with `--default`:
 
 ```shell
 $ snap get --default=acme-default <account-id>/network/wifi-state acme.ssid
 acme-default
 ```
 
-Snaps can use the same `--default` flag through `snapctl get --view`. In both cases, `--default` can only be used when requesting a single path. The value is returned to the caller only and isn't stored, so every reader must supply its own `--default`.
+In both cases, `--default` can only be used when requesting a single path.
 
 ## Getting secret data
 *From snapd version 2.76+*

--- a/docs/how-to-guides/manage-snaps/configure-snaps-with-confdb.md
+++ b/docs/how-to-guides/manage-snaps/configure-snaps-with-confdb.md
@@ -339,6 +339,34 @@ Note that concurrent accesses may block if they would result in writes running c
 
 For example, if there is a read ongoing and a write is requested, the write will be blocked. A new read would then also be queued and only run after the write, even though reads are normally run concurrently. This ensures that a stream of reads cannot starve a write access.
 
+## Default values
+
+Confdb has no schema-level mechanism for declaring default values. There are two ways to provide them.
+
+### Supplying a default per request
+
+If no value has been set for a requested path, `snap get` returns an error. You can supply a fallback with `--default`:
+
+```shell
+$ snap get --default=acme-default <account-id>/network/wifi-state acme.ssid
+acme-default
+```
+
+Snaps can use the same `--default` flag through `snapctl get --view`. In both cases, `--default` can only be used when requesting a single path. The value is returned to the caller only and isn't stored, so every reader must supply its own `--default`.
+
+### Populating defaults with a load-view hook
+
+To avoid each caller passing a flag, a custodian snap can populate a default with a `load-view-<plug>` hook. snapd runs this hook on every read through the custodian's view, so it can set any path that has no value before the read is served:
+
+```shell
+#!/bin/bash -xe
+
+# set a default ssid if one hasn't been configured
+if ! snapctl get --view :network-wifi-admin acme.ssid >/dev/null 2>&1; then
+  snapctl set --view :network-wifi-admin acme.ssid=acme-default
+fi
+```
+
 ## Getting secret data
 *From snapd version 2.76+*
 

--- a/docs/how-to-guides/manage-snaps/configure-snaps-with-confdb.md
+++ b/docs/how-to-guides/manage-snaps/configure-snaps-with-confdb.md
@@ -341,11 +341,7 @@ For example, if there is a read ongoing and a write is requested, the write will
 
 ## Default values
 
-Confdb has no schema-level mechanism for declaring default values. There are two ways to provide them.
-
-### Supplying a default per request
-
-If no value has been set for a requested path, `snap get` returns an error. You can supply a fallback with `--default`:
+Confdb has no schema-level mechanism for declaring default values. If no value has been set for a requested path, `snap get` returns an error. You can supply a fallback with `--default`:
 
 ```shell
 $ snap get --default=acme-default <account-id>/network/wifi-state acme.ssid
@@ -353,19 +349,6 @@ acme-default
 ```
 
 Snaps can use the same `--default` flag through `snapctl get --view`. In both cases, `--default` can only be used when requesting a single path. The value is returned to the caller only and isn't stored, so every reader must supply its own `--default`.
-
-### Populating defaults with a load-view hook
-
-To avoid each caller passing a flag, a custodian snap can populate a default with a `load-view-<plug>` hook. snapd runs this hook on every read through the custodian's view, so it can set any path that has no value before the read is served:
-
-```shell
-#!/bin/bash -xe
-
-# set a default ssid if one hasn't been configured
-if ! snapctl get --view :network-wifi-admin acme.ssid >/dev/null 2>&1; then
-  snapctl set --view :network-wifi-admin acme.ssid=acme-default
-fi
-```
 
 ## Getting secret data
 *From snapd version 2.76+*


### PR DESCRIPTION
Robotics flagged that providing default values for confdb configuration isn't well documented. This PR adds a "Default values" section covering two approaches: supplying a per-request fallback with the `--default flag` on `snap get` and `snapctl get --view`, and populating a default from a custodian's `load-view-<plug>` hook so callers don't each have to pass one.

CC: @miguelpires 