### PR TITLE
snap-docs: update interface reference information for system-packages…

### DIFF
--- a/docs/reference/interfaces/system-packages-doc-interface.md
+++ b/docs/reference/interfaces/system-packages-doc-interface.md
@@ -10,7 +10,10 @@ The `system-packages-doc` interface permits access file system locations used to
 * `/usr/share/javascript/`
 * `/usr/share/libreoffice/help/`
 * `/usr/share/sphinx_rtd_theme/`
-* `/usr/share/xubuntu-docs/	`
+* `/usr/share/xubuntu-docs/`
+* `/usr/share/help/`
+* `/usr/share/info/`
+* `/usr/share/man/`
 
 After the interface has been connected, the host’s `/usr/share/doc` directory replaces the `/usr/share/doc` for the context of the snap.
 


### PR DESCRIPTION
Discovered `system-packages-doc` interface documentation is out-of-date. This PR adds documentation for the changes made in https://github.com/canonical/snapd/pull/16681.