### PR TITLE
docs: extend notes on the recommended state of services during snapshot operations

### DIFF
--- a/docs/how-to-guides/manage-snaps/create-data-snapshots.md
+++ b/docs/how-to-guides/manage-snaps/create-data-snapshots.md
@@ -18,6 +18,8 @@ Set  Snap         Age    Version               Rev   Size   Notes
 30   vlc          529ms  3.0.6                 770   882kB  -
 ```
 
+> Before using this command, in order to ensure consistency of saved data, it is recommended to stop all applications and services of the snap (`snap stop <snap-name>`). Start them again once the snapshot has been saved.
+
 Each snapshot has a unique ID, or revision, shown in the *Set* column above. This value is unique to each *save* operation, regardless of the number of snaps it includes. *Age* is the period of time since the snapshot was created, while *Version* and *Rev* refer to the specific snap at the time of the snapshot. *Size* is the amount of storage used by a snapshot. 
 
 If you'd rather not wait for the *save* operation to complete before regaining access to your terminal, add the `--no-wait` argument.
@@ -102,8 +104,7 @@ $ sudo snap restore 30
 Restored snapshot #30.
 ```
 
-Before using this command, make sure you have the snap application installed, and that its services, if any, are stopped (`snap stop <snap-name>`). 
-Start them again once the snapshot has been successfully restored.
+> Before using this command, make sure you have the snap installed, and that its applications and services, if any, are stopped (`snap stop <snap-name>`). Start them again once the snapshot has been successfully restored.
 
 By default, this command restores all the data for all the snaps in a snapshot. You can restore data for specific snaps by simply listing them after the command and for specific users with the `--users=<usernames>` argument.
 

--- a/docs/how-to-guides/manage-snaps/create-data-snapshots.md
+++ b/docs/how-to-guides/manage-snaps/create-data-snapshots.md
@@ -19,7 +19,7 @@ Set  Snap         Age    Version               Rev   Size   Notes
 ```
 
 ```{caution}
-Before using this command, in order to ensure consistency of saved data, make sure to stop all applications and services of the snaps included in the snapshot (`snap stop <snap-name>`). Start them again once the snapshot has been saved.
+Before using this command, stop any services for the snaps included in the snapshot (`snap stop <snap-name>`) and close any running applications provided by those snaps. Start them again once the snapshot has been saved.
 ```
 
 Each snapshot has a unique ID, or revision, shown in the *Set* column above. This value is unique to each *save* operation, regardless of the number of snaps it includes. *Age* is the period of time since the snapshot was created, while *Version* and *Rev* refer to the specific snap at the time of the snapshot. *Size* is the amount of storage used by a snapshot. 
@@ -107,7 +107,7 @@ Restored snapshot #30.
 ```
 
 ```{caution}
-Before using this command, make sure you have the snap installed, and that its applications and services, if any, are stopped (`snap stop <snap-name>`). Start them again once the snapshot has been successfully restored.
+Before using this command, make sure the snap is installed, then stop its services (`snap stop <snap-name>`) and close any running applications provided by that snap. Start them again once the snapshot has been successfully restored.
 ```
 
 By default, this command restores all the data for all the snaps in a snapshot. You can restore data for specific snaps by simply listing them after the command and for specific users with the `--users=<usernames>` argument.

--- a/docs/how-to-guides/manage-snaps/create-data-snapshots.md
+++ b/docs/how-to-guides/manage-snaps/create-data-snapshots.md
@@ -18,7 +18,9 @@ Set  Snap         Age    Version               Rev   Size   Notes
 30   vlc          529ms  3.0.6                 770   882kB  -
 ```
 
-> Before using this command, in order to ensure consistency of saved data, it is recommended to stop all applications and services of the snap (`snap stop <snap-name>`). Start them again once the snapshot has been saved.
+```{caution}
+Before using this command, in order to ensure consistency of saved data, make sure to stop all applications and services of the snaps included in the snapshot (`snap stop <snap-name>`). Start them again once the snapshot has been saved.
+```
 
 Each snapshot has a unique ID, or revision, shown in the *Set* column above. This value is unique to each *save* operation, regardless of the number of snaps it includes. *Age* is the period of time since the snapshot was created, while *Version* and *Rev* refer to the specific snap at the time of the snapshot. *Size* is the amount of storage used by a snapshot. 
 
@@ -104,7 +106,9 @@ $ sudo snap restore 30
 Restored snapshot #30.
 ```
 
-> Before using this command, make sure you have the snap installed, and that its applications and services, if any, are stopped (`snap stop <snap-name>`). Start them again once the snapshot has been successfully restored.
+```{caution}
+Before using this command, make sure you have the snap installed, and that its applications and services, if any, are stopped (`snap stop <snap-name>`). Start them again once the snapshot has been successfully restored.
+```
 
 By default, this command restores all the data for all the snaps in a snapshot. You can restore data for specific snaps by simply listing them after the command and for specific users with the `--users=<usernames>` argument.
 


### PR DESCRIPTION
Extend notes on the recommended state of services and applications when saving or restoring snapshots.