### PR TITLE
build: rename sitemap

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -189,7 +189,7 @@ sitemap_show_lastmod = True
 
 
 # Default name conflicts with RTD's sitemap generation
-# sitemap_filename = "sitemap.xml"
+sitemap_filename = "doc-sitemap.xml"
 
 # Exclude generated pages from the sitemap:
 


### PR DESCRIPTION
Because these docs don't use a version or language slug, RTD defaults to the sitemap at the site root. There's a bug with RTD where this file is unavailable after our builds, so we need to rename it.