### PR TITLE
docs: mention SNAP_COMPONENTS

### DIFF
--- a/docs/explanation/how-snaps-work/snap-components.md
+++ b/docs/explanation/how-snaps-work/snap-components.md
@@ -102,4 +102,4 @@ Component hooks run as confined snap applications, which is also the case for al
 ## Accessing components from within a snap environment
 
 Within the snap environment, all available components of the snap are declared in `$SNAP/meta/snap.yaml`.
-All installed components are exposed under `$SNAP/../components/$SNAP_REVISION/`. The content of each component is available under `$SNAP/../components/$SNAP_REVISION/<comp-name>/` and the presence of this non-empty directory indicates that a given component is installed.
+All installed components are exposed under `$SNAP_COMPONENTS/`, which is the same path as `$SNAP/../components/$SNAP_REVISION/` used with _snapd_ older than 2.78. The content of each component is available under `$SNAP_COMPONENTS/<comp-name>/` and the presence of this non-empty directory indicates that a given component is installed.

--- a/docs/reference/development/environment-variables.md
+++ b/docs/reference/development/environment-variables.md
@@ -225,6 +225,15 @@ Typical value: `org.example.Foo`
 
 Requires _snapd_ 2.77+.
 
+### <pre>SNAP_COMPONENTS</pre>
+
+Path to components directory. Installed components are available under
+`$SNAP_COMPONENTS/<comp-name>/`.
+
+Typical value: /snap/hello-world/components/27
+
+Requires _snapd_ 2.78+
+
 ## Generic variables
 
 ### <pre>HOME</pre>


### PR DESCRIPTION
Snapd 2.78 adds SNAP_COMPONENTS ([PR](https://github.com/canonical/snapd/pull/17435)) which should be preferred over manually assembled path to the components directory.