### PR TITLE
docs: fix typos; add new exceptions to wordlist

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -4,6 +4,7 @@ allquotas
 alsa
 API
 apparmor
+[Aa]utostart
 auditd
 backend
 backends
@@ -99,6 +100,7 @@ guiscrcpy
 gyre
 gzip
 hardcoding
+hashbang
 hidraw
 HMACs
 homedirs
@@ -156,6 +158,7 @@ manpage
 [Mm]aster
 microcontroller
 microcontrollers
+mitigations
 mmap
 mmc
 mountspace
@@ -247,6 +250,8 @@ stdout
 [Ss]trace
 subproject
 subprojects
+subgid
+subuid
 sudo
 SVG
 syscall
@@ -283,6 +288,7 @@ unmounting
 unnasserted
 unpackaged
 unsandboxed
+[Uu]nsquashing
 Unsetting
 unsetting
 unsquash

--- a/docs/explanation/how-snaps-work/confdb-configuration-mechanism.md
+++ b/docs/explanation/how-snaps-work/confdb-configuration-mechanism.md
@@ -186,7 +186,7 @@ Requests are compared to rule prefixes until a match occurs which means an empty
 
 ##### Namespaces
 
-If there is a change in the configuration data’s layout, only the assertion needs to be modified. The snap sees the same namespace, isolating it from schema changes. For example, the following assertion exposes the same data under the same namespace (from a user or snap’s perspective) but the storage layout it assumes is completely different:
+If the configuration data layout changes, only the assertion needs to be modified. The snap sees the same namespace, isolating it from schema changes. For example, the following assertion exposes the same data under the same namespace (from a user or snap’s perspective) but the storage layout it assumes is completely different:
 
 ```yaml
 ...

--- a/docs/explanation/security/api-authentication-and-authorization.md
+++ b/docs/explanation/security/api-authentication-and-authorization.md
@@ -60,7 +60,7 @@ UNIX domain socket peer credentials (`SO_PEERCRED`) allows a server to securely 
 
 Snapd authenticates snaps by performing a cgroup lookup using the process PID obtained from peer credentials to determine which snap the requesting process belongs to. This identifies the calling snap, whose connected interfaces are then used for authorization decisions. The cgroup is assigned during process bootstrap, and the sandbox prevents the snap process from moving itself to a different cgroup, which helps protect this mechanism against spoofing.
 
-#### Polkit authenticaton requests
+#### Polkit authentication requests
 
 Certain snapd API operations are authorized via Polkit. For these operations, snapd queries Polkit to determine whether the caller is permitted to perform the requested action. Polkit is an authorization framework that may require user or administrator authentication before authorization is granted.
 


### PR DESCRIPTION
The checks were failing due to a few typos and unrecognized words.