### PR TITLE
docs: clarify custodian role and fix view rule indentation in confdb guide

### DIFF
--- a/docs/how-to-guides/manage-snaps/configure-snaps-with-confdb.md
+++ b/docs/how-to-guides/manage-snaps/configure-snaps-with-confdb.md
@@ -89,7 +89,7 @@ See [confdb-schema types](https://documentation.ubuntu.com/core/reference/assert
 
 Now let’s create some view rules to access confdb.
 
-In our example, we'll use one snap to configure the network and another to access it, which means we need two views: `wifi-admin` and `wifi-state`.
+In our example, we’ll use one snap as the custodian of both views, which also allows changes to the network configuration, and another snap to access it. This means we need two views: `wifi-admin` and `wifi-state`.
 
 * `wifi-admin` exposes parameters and allows them to be set.
 * `wifi-state` allows the snap to list Wi-Fi connections and read SSID and state information (e.g., up, down).
@@ -108,27 +108,27 @@ views:
     summary: Configure Wi-Fi networks
     rules:
       -
-      request: "{name}.ssid"
-      storage: "v1.wifi.{name}.ssid"
+        request: "{name}.ssid"
+        storage: "v1.wifi.{name}.ssid"
       -
-      request: "{name}.password"
-      storage: "v1.wifi.{name}.psk"
+        request: "{name}.password"
+        storage: "v1.wifi.{name}.psk"
       -
-      request: "{name}.state"
-      storage: "v1.wifi.{name}.state"
+        request: "{name}.state"
+        storage: "v1.wifi.{name}.state"
 
   wifi-state:
     summary: List and read Wi-Fi SSIDs
     rules:
       -
-      request: "{name}"
-      storage: "v1.wifi.{name}"
-      access: read
-      content:
+        request: "{name}"
+        storage: "v1.wifi.{name}"
+        access: read
+        content:
         -
-        storage: ssid
+          storage: ssid
         -
-        storage: state
+          storage: state
 
 body-length: 552
 sign-key-sha3-384: 74KHeq1foV…
@@ -225,7 +225,7 @@ Custodian snaps have a special role when accessing ephemeral data. They're respo
 
 The data that snapd stores for ephemeral configuration is only a cached, non-authoritative version of the external data. At least one custodian snap must be installed in the system for a particular confdb-schema.
 
-The first snap will configure the Wi-Fi network to be used, so let’s configure it accordingly:
+The first snap will act as the custodian for both views as well as allowing configuration of the Wi-Fi network, so let’s configure it accordingly:
 
 ```yaml
 plugs:
@@ -233,6 +233,11 @@ plugs:
     interface: confdb
     account: <account-id>
     view: network/wifi-admin
+    role: custodian
+  network-wifi-state:
+    interface: confdb
+    account: <account-id>
+    view: network/wifi-state
     role: custodian
 ```
 
@@ -260,7 +265,7 @@ That’s it for the custodian snap.
 
 ### Reader snap
 
-Now we’ll create a snap that will read the configuration. Its plug will reference the read-only view and it will omit the `role`:
+Now we’ll create a snap that will only read the configuration. Its plug will reference the read-only view and it will omit the `role`:
 
 ```yaml
 plugs:
@@ -289,6 +294,7 @@ Note that when a snap is published by the same account ID as the assertion, the 
 ```shell
 snap install custodian-snap reader-snap
 snap connect custodian-snap:network-wifi-admin
+snap connect custodian-snap:network-wifi-state
 snap connect reader-snap:network-wifi-state
 ```
 


### PR DESCRIPTION
Reworks the confdb how-to guide following review feedback. This supersedes #377, which had picked up a bad rebase.

Closes DMENG-975 — see https://warthogs.atlassian.net/browse/DMENG-975

## Changes

- Describe the first snap as the **custodian of both views**, making it clear that every view needs a custodian even when that snap doesn't read from it.
- Add the second custodian plug (`network-wifi-state`) and its corresponding `snap connect` command.
- Fix the YAML indentation of the view rules. As previously written, `request`/`storage` parsed as siblings of the list rather than as list entries, so the sample was not a valid confdb-schema.
- Clarify that the reader snap *only* reads the configuration.

## Review feedback from #377

All comments raised on #377 are addressed here:

| Comment | Resolution |
| --- | --- |
| @st3v3nmw: "host" implies residence; prefer the reference doc's framing | Reworded to "one snap as the custodian of both views, which also allows changes to the network configuration, and another snap to access it" |
| @st3v3nmw: the rebase undid #378 — view renames and `v1` storage prefix | View names `wifi-admin`/`wifi-state` and the `v1.` storage prefix are preserved |
| @miguelpires: view rules restore pre-SD247 storage paths | `v1.wifi.{name}.*` retained |
| @miguelpires: `snap connect` block uses pre-SD247 plug names | Uses `network-wifi-admin`/`network-wifi-state` |
| @miguelpires: `snap change` output uses pre-SD247 names | That block is left untouched, so the SD247 names stand |
| @miguelpires: view names in the prose are the old ones | Prose now uses `wifi-admin` and `wifi-state` |