### PR TITLE
docs: fix typos in explanation and how-to guides

### DIFF
--- a/docs/explanation/how-snaps-work/index.md
+++ b/docs/explanation/how-snaps-work/index.md
@@ -7,7 +7,7 @@ myst:
 (explanation-how-snaps-work-index)=
 # How snaps work
 
-Understand how snaps update automatically, and use revisions and transactional updates to mange risk and mitigate potential issues.
+Understand how snaps update automatically, and use revisions and transactional updates to manage risk and mitigate potential issues.
 
 * {ref}`Refresh awareness <explanation-how-snaps-work-refresh-awareness>`: How updates are handled when apps are running.
 * {ref}`Using channels <explanation-how-snaps-work-channels-and-tracks>`: Understanding channels, tracks, risk-levels and branches.

--- a/docs/explanation/index.md
+++ b/docs/explanation/index.md
@@ -11,7 +11,7 @@ Our explanatory and conceptual guides are written to provide a better understand
 
 ## How snaps work
 
-Understand how snaps update automatically, and use revisions and transactional updates to mange risk and mitigate potential issues.
+Understand how snaps update automatically, and use revisions and transactional updates to manage risk and mitigate potential issues.
 
 * {ref}`Refresh awareness <explanation-how-snaps-work-refresh-awareness>`: How updates are handled when apps are running.
 * {ref}`Using channels <explanation-how-snaps-work-channels-and-tracks>`: Understanding channels, tracks, risk-levels and branches.
@@ -32,7 +32,7 @@ As you begin to use snaps more, interfaces can be used to carefully permit and l
 Learn about how snaps use standard Linux security policies to isolate themselves from the system, and from each other.
 
 * {ref}`Security policies <explanation-security-security-policies>`: How we use AppArmor, Seccomp and cgroups to secure snaps.
-* {ref}`Snap confinement <explanation-security-snap-confinement>`: Learn more about snap's various degrees of isolation.
+* {ref}`Snap confinement <explanation-security-snap-confinement>`: Learn more about Snap's various degrees of isolation.
 * {ref}`Assertions <explanation-security-assertions>`: Digitally signed documents used to verify all snap artefacts.
 * {ref}`Snapd release process <explanation-security-snapd-release-process>`: How and when we update the snapd package.
 

--- a/docs/explanation/security/index.md
+++ b/docs/explanation/security/index.md
@@ -11,7 +11,7 @@ Learn about how snaps use standard Linux security policies to isolate themselves
 
 * {ref}`Security policies <explanation-security-security-policies>`: How we use AppArmor, Seccomp and cgroups to secure snaps.
 * {ref}`Assertions <explanation-security-assertions>`: Digitally signed documents used to verify all snap artefacts.
-* {ref}`Snap confinement <explanation-security-snap-confinement>`: Learn more about snap's various degrees of isolation.
+* {ref}`Snap confinement <explanation-security-snap-confinement>`: Learn more about Snap's various degrees of isolation.
 * {ref}`Classic confinement <explanation-security-classic-confinement>`: Learn more about classic confinement.
 * {ref}`API authentication and authorization <explanation-security-api-authentication-and-authorization>`: How snapd authenticates API callers and authorizes operations.
 * {ref}`Decommissioning <explanation-security-decommissioning>`: How to completely remove snapd and associated data.

--- a/docs/how-to-guides/index.md
+++ b/docs/how-to-guides/index.md
@@ -20,7 +20,7 @@ The snap system has been designed to look after itself with automatic security a
 
 ## Manage snaps
 
-Outside of whatever facilities a snapped application may provide, snaps also provides data snapshots, usage quotas and control over if when when a service runs.
+Outside of whatever facilities a snapped application may provide, snaps also provides data snapshots, usage quotas and control over if and when a service runs.
 
 * {ref}`Create data snapshots <how-to-guides-manage-snaps-create-data-snapshots>`: Make a copy of a snap's user, system and configuration data.
 * {ref}`Use quota resources <how-to-guides-manage-snaps-use-resource-quotas>`: Set processor and memory resource limits on your snaps.

--- a/docs/how-to-guides/manage-snaps/index.md
+++ b/docs/how-to-guides/manage-snaps/index.md
@@ -7,7 +7,7 @@ myst:
 (how-to-guides-manage-snaps-index)=
 # Manage snaps
 
-Outside of whatever facilities a snapped application may provide, additional snap functionality includes  data snapshots, usage quotas and control over if when when a service runs.
+Outside of whatever facilities a snapped application may provide, additional snap functionality includes  data snapshots, usage quotas and control over if and when a service runs.
 
 ## System configuration
 


### PR DESCRIPTION
Fix several minor grammatical and typographical errors:
- Fix "mange" -> "manage" in how-snaps-work index and general explanation index
- Fix "if when when" / "if when" -> "if and when" in manage-snaps guides
- Capitalize "snap's" -> "Snap's" in security index pages