### PR TITLE
docs: restore uc20 fde page and fix hooks page

### DIFF
--- a/docs/redirects.txt
+++ b/docs/redirects.txt
@@ -69,6 +69,7 @@ super-privileged-interfaces/ explanation/interfaces/super-privileged-interfaces
 network-requirements/ reference/administration/network-requirements
 distro-support/ reference/administration/distribution-support
 supported-snap-hooks/ reference/development/supported-snap-hooks
+uc20-fde-hooks/ reference/development/uc20-fde-hooks/
 services-and-daemons/ how-to-guides/manage-snaps/control-services
 environment-variables/ reference/development/environment-variables
 snapd-error-codes/ reference/development/error-responses

--- a/docs/reference/development/index.md
+++ b/docs/reference/development/index.md
@@ -32,6 +32,7 @@ YAML schemas define exactly what a device, kernel and snap is capable of.
 Environment variables <environment-variables>
 API Error codes <error-responses>
 Supported hooks <supported-snap-hooks>
+Full-disk-encryption hooks <uc20-fde-hooks>
 Experimental features <experimental-features>
 SnapD REST API <snapd-rest-api>
 YAML schemas <yaml-schemas/index>

--- a/docs/reference/development/supported-snap-hooks.md
+++ b/docs/reference/development/supported-snap-hooks.md
@@ -58,7 +58,8 @@ This allows for changes to be rolled back or *unset* if errors occur during the 
 
 ---
 
-<h2 id='heading--the-configure-hook'>The configure hook<sup><a href='#heading--the-configure-hook'>⚓</a></sup></h2>
+<span id="heading--the-configure-hook"></span>
+## The configure hook
 
 The `configure` hook is called every time one the following actions happen:
 
@@ -100,7 +101,8 @@ The same hook can also modify the configuration of a snap within the context of 
 
 > ⓘ Note that configuration options do not need to be defined anywhere. `snapctl set` and `snap set` will accept any (valid) option name.
 
-<h2 id='heading--default-configure'>The default-configure hook</h2>
+<span id="heading--default-configure"></span>
+## The default-configure hook
 
 The default-configure-hook is an optional extension to the {ref}`configure hook <reference-development-supported-snap-hooks>` that executes only on snap installation and _before_ services are started to provide access to the default configuration values stored in a device’s {ref}`gadget snap <reference-development-yaml-schemas-the-gadget-snap>`.
 
@@ -126,15 +128,17 @@ echo "option: $gadget_option" > $SNAP_DATA/options/gadget
 
 For more information see {ref}`Adding Snap configuration <how-to-guides-manage-snaps-set-system-options>` and {ref}`Using the snapctl tool <how-to-guides-manage-snaps-use-snapctl>`.
 
-<h2 id='heading--fde'>The full-disk-encryption hook</h2>
+<span id="heading--fde"></span>
+## The full-disk-encryption hook
 
 [Ubuntu Core 20 ](https://ubuntu.com/core/docs/uc20/) (UC20) uses [full disk encryption](https://ubuntu.com/core/docs/uc20/full-disk-encryption) (FDE) whenever the hardware allows, protecting both the confidentiality and integrity of a device’s data when there’s physical access to a device, or after a device has been lost or stolen.
 
 Creating a verifiable boot process on a non-standard (non-UEFI+TPM platform) FDE platform, such as a Raspberry Pi or other ARM devices, is board-specific and will typically involve creating custom gadget and kernel snaps. UC20, however, does provide a helper mechanism, via a hook interface, to ensure the integrity of any subsequently executed or accessed data.
 
-See [UC20 full-disk-encryption hook interface](https://snapcraft.io/docs/reference/development/supported-snap-hooks/) for details on how this hook is implemented.
+See {ref}`Full-disk-encryption hooks <reference-development-uc20-fde-hooks>` for details on how this hook is implemented..
 
-<h2 id='heading--gate-auto-refresh'>The gate-auto-refresh hook</h2>
+<span id="heading--gate-auto-refresh"></span>
+## The gate-auto-refresh hook
 
 The gate-auto-refresh hook is executed by snapd for every snap that will be updated with the next automatic refresh. It’s also executed for every snap that is dependent on a snap that will be updated.
 
@@ -142,19 +146,22 @@ This hook is capable of executing the snapctl refresh command with 3 specific ar
 
 This feature is currently considered experimental. See {ref}`Refresh control <how-to-guides-work-with-snaps-manage-updates>` for more details.
 
-<h2 id='heading--install'>The install hook</h2>
+<span id="heading--install"></span>
+## The install hook
 
 The `install` hook is called upon initial install only, i.e. it's not called on subsequent refreshes.
 
 The hook is executed before starting snap services (if it has any) and before the `configure` hook. The install hook is the place for one-time actions, such as an early initialisation of a resource when installed for the first time.
 
-<h2 id='heading--install-device'>The install-device hook</h2>
+<span id="heading--install-device"></span>
+## The install-device hook
 
 This hook is supported in Ubuntu Core 20 and subsequent releases.
 
 See [Installation process](https://ubuntu.com/core/docs/uc20/installation-process#heading--install-device) in the Ubuntu Core documentation for more details.
 
-<h2 id='heading--interface'>The interface hooks</h2>
+<span id="heading--interface"></span>
+## The interface hooks
 
 Interface hooks are executed when an interface is either connected or disconnected via the interface’s plugs and slots mechanism.
 
@@ -162,20 +169,23 @@ They can be used to read or write attributes from a connection and, for example,
 
 For further details, see {ref}`Interface hooks <explanation-interfaces-interface-hooks>`.
 
-<h2 id='heading--prepare-device'>The prepare-device hook</h2>
+<span id="heading--prepare-device"></span>
+## The prepare-device hook
 
 This hook is only supported in gadget snaps.
 
 See {ref}`The gadget snap <reference-development-yaml-schemas-the-gadget-snap>` documentation for more details.
 
-<h2 id='heading--prepare-serial'>The prepare-serial hook</h2>
+<span id="heading--prepare-serial"></span>
+## The prepare-serial hook
 
 This hook is only supported in gadget snaps.
 
 See {ref}`The gadget snap <reference-development-yaml-schemas-the-gadget-snap>` documentation for more details.
 
 
-<h2 id='heading--pre-refresh'>The pre-refresh hook</h2>
+<span id="heading--pre-refresh"></span>
+## The pre-refresh hook
 
 The `pre-refresh` hook is called whenever the snap gets refreshed. 
 
@@ -185,7 +195,8 @@ This hook is a good place for any maintenance or cleanup actions that prepare th
 
 The `pre-refresh` hook is not executed when {ref}`snap revert <tutorials-get-started>` is used to install an earlier revision of a snap. If such an operation affects snap functionality, the snap needs to detect this action and manually perform whatever actions may be necessary.
 
-<h2 id='heading--post-refresh'>The post-refresh hook</h2>
+<span id="heading--post-refresh"></span>
+## The post-refresh hook
 
 The `post-refresh` hook is similar to `pre-refresh` (above) in that it is called whenever the snap gets refreshed.
 
@@ -193,9 +204,9 @@ This hook is executed for the newly installed revision of the snap, before start
 
 The `post-refresh` hook is not executed when {ref}`snap revert <tutorials-get-started>` is used to install an earlier revision of a snap. If such an operation affects snap functionality, the snap needs to detect this action and manually perform whatever actions may be necessary.
 
-<h2 id='heading--remove'>The remove hook</h2>
+<span id="heading--remove"></span>
+## The remove hook
 
 The `remove` hook is called when the last revision of the snap gets removed from the system.
 
 This hook is executed after stopping the services of the snap (if the snap has any services), therefore it's useful for any custom cleanup logic.
-

--- a/docs/reference/development/uc20-fde-hooks.md
+++ b/docs/reference/development/uc20-fde-hooks.md
@@ -1,0 +1,136 @@
+---
+myst:
+  html_meta:
+    description: Implement full-disk encryption for Ubuntu Core with the fde-setup hook and fde-reveal-key helper.
+---
+
+(reference-development-uc20-fde-hooks)=
+# UC20+ FDE Hooks
+
+[Ubuntu Core](https://documentation.ubuntu.com/core/) 20 and later (UC20+) use [full disk encryption](https://documentation.ubuntu.com/core/explanation/full-disk-encryption/) (FDE) whenever the hardware allows, protecting both the confidentiality and integrity of a device’s data when there’s physical access to a device, or after a device has been lost or stolen.
+
+Creating a verifiable boot process on a non-standard (non-UEFI+TPM and non-OPTEE) FDE platform, such as on a Raspberry Pi or other ARM devices, is board-specific and will typically involve creating custom gadget and kernel snaps. UC20+, however, does provide a helper mechanism, via a hook interface, to ensure the integrity of any subsequently executed or accessed data. This process is outlined below.
+
+> If your platform supports OP-TEE, we strongly encourage using the [OP-TEE full disk encryption](https://documentation.ubuntu.com/core/explanation/full-disk-encryption-op-tee/) hooks instead.
+
+> [Get in touch](https://ubuntu.com/core/contact-us?product=core-overview) to discuss bespoke requirements for non-standard FDE platforms.
+
+- [Using the hook](#heading--hooks)
+- [Data handling](#heading--data)
+  - [fde-reveal-key](#heading--fde-reveal-key)
+  - [fde-setup](#heading--fde-setup)
+    - [op: features](#heading--features)
+    - [op: initial-setup](#heading--initial-setup)
+- [Implementation examples](#heading--examples)
+- [Future development](#heading--future)
+
+<span id="heading--hooks"></span>
+## Using the hook
+
+Snapd uses the {ref}`hook <reference-development-supported-snap-hooks>` mechanism in the kernel snap to run hook-specific executable binaries. The first retrieves the encryption key and unlocks the disk while the second is called on installation/re-installation to ensure the key is sealed.
+
+- The first binary is executed from the initrd and is located inside the _initrd_ $PATH, e.g. `usr/bin/fde-reveal-key`.
+
+  This is used by snap-bootstrap initramfs-mounts to retrieve the key and unlock the disk. It does not run with typical snapd confinement, using systemd mechanisms instead to restrict the helper and ensure it is not misused to change the ubuntu-data partition in uncontrolled ways.
+
+- The second binary is executed from the install/reinstall process to ensure the key is sealed.
+
+  It is run as a normal hook `meta/hooks/fde-setup` from the kernel snap with corresponding `snapctl fde-setup-request` and `snapctl fde-setup-result` commands that can be used from the hook.
+
+If `fde-reveal-key` and `meta/hooks/fde-setup` exist, they're used for all FDE operations instead of the built-in TPM code.
+
+<span id="heading--data"></span>
+## Data handling
+
+The helper mechanism is stateless, with snapd providing whatever data is necessary.
+
+When protecting a key, for instance, `fde-setup` returns a "handle" consisting of any valid JSON, such as a string with base64-encoded binary data, which could then be used as auxiliary data to help unseal/decrypt the protected key.
+
+Apart from ensuring the data is valid JSON, or when the data is passed back to `fde-reveal-key` (see below), snapd stores and handles this data completely opaquely.
+
+<span id="heading--fde-reveal-key"></span>
+### Data for fde-reveal-key
+
+As mentioned earlier, the `fde-reveal-key` binary is run from _initrd_. It gets data via _stdin_ and outputs the data to stdout.
+
+<span id="heading--fde-reveal"></span>
+#### op: reveal
+
+In this operation the revealed key is written to _stdout_. The data passed via _stdin_ is JSON:
+
+```text
+{
+    "op": "reveal",                 // more may be added in the future
+    "sealed-key": "<base64-encoded-bytes>",
+    "handle": <handle-valid-json>,  // opaque handle (can be empty)
+                                    // as returned previously by fde-setup
+}
+```
+
+It returns: `{"key": "base64 encoded key"}` to allow additional future capabilities.
+
+Any exit code other than `0` is expected to return an error string to _stderr_.
+
+<span id="heading--fde-lock"></span>
+#### op: lock
+
+When the hook is called in this way, access to the keys should be locked using a method appropriate for the underlying hardware.
+
+<span id="heading--fde-setup"></span>
+### Data for fde-setup
+
+`fde-setup` is a normal snapd hook and uses {ref}`snapctl <how-to-guides-manage-snaps-use-snapctl>` to communicate with snapd.
+
+The workflow for the hook is that it calls `snapctl fde-setup-request` and reads the JSON from _stdout_. The JSON will contain an `op` field that tells the hook what to do.
+
+The result is operation dependent and should be set via _stdin_ to `snapctl fde-setup-result`.
+
+<span id="heading--features"></span>
+#### op: features
+
+If the `fde-setup` hook is run with `"op": "features"` (see above), the hook should report, via JSON, a JSON-formatted array containing the features it supports. Initially this will just be an empty list: `[]`.
+
+For example
+
+```bash
+$ snapctl fde-setup-request
+{"op":"features"}
+
+$ echo '{"features": []}' | snapctl fde-setup-result
+```
+
+Currently, this is mostly to future proof hooks/snapd.
+
+<span id="heading--initial-setup"></span>
+#### op: initial-setup
+
+If the `fde-setup` hook is run with `"op": "initial-setup"`, the hook should call `snapctl fde-setup-request`, passing the following JSON to _stdout_:
+
+```text
+{
+    "op": "initial-setup",      // valid: "initial-setup","update"
+    "key": <base64-encoded-payload-that-should-be-encrypted/sealed>,
+}
+```
+
+When the hook has completed the encryption and sealing, it will call:
+
+```bash
+$ echo '{"sealed-key": "<base64-sealed-or-encrypted-key>", "handle": <opaque-handle-valid-JSON> }' | snapctl fde-setup-result
+```
+
+Any exit code other than `0` is expected to return an error string to _stderr_.
+
+<span id="heading--examples"></span>
+## Implementation examples
+
+- snapd example, used for integration testing in _go_ ( (insecure as it's software only):
+  <https://github.com/snapcore/snapd/blob/master/tests/lib/fde-setup-hook/fde-setup.go>
+
+- Production grade OP-TEE implementation written in C:
+  <https://git.launchpad.net/~ondrak/+git/optee-uc-fde/tree/host/fde_key_manager/>
+
+<span id="heading--future"></span>
+## Future development
+
+The current spec does not include boot chains or a method of tacking what specific boot assets are measured. Consequently, these hooks cannot currently be used for systems that require measurements.


### PR DESCRIPTION
This restore the UC20 FDE hooks page (removed in https://github.com/canonical/snap-docs/pull/42/changes/31d14861ad652f68a8581977e106c805657647f5) and fixes some broken links related to it. @valentindavid (or someone else familiar) can you confirm that this page is still correct and should be listed? 

This also fixes some headings in the supported-snap-hooks.md which resulted in most of them not being in the content sidelist:

Before:
<img width="304" height="146" alt="Screenshot from 2026-08-25 14-16-04" src="https://github.com/user-attachments/assets/5117a3e9-3ad2-4871-a91b-e18b714dc944" />

After:
<img width="348" height="462" alt="Screenshot from 2026-08-25 14-43-32" src="https://github.com/user-attachments/assets/ae77ba28-2cbc-46d6-8329-383608568abb" />

There will also be another PR in the ubuntu-core-docs repo to fix links to the restored page.